### PR TITLE
Filter fields by tagOpts based on a given function

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -21,7 +21,7 @@ type Struct struct {
 	value   reflect.Value
 	TagName string
 	TagOptsFieldOmitter TagOptsFieldOmitter
-	IncludeEmptyConversions bool
+	IncludeEmptyConversions bool // Determines if empty maps are okay to display in the conversion
 }
 
 // TagOptsFieldOmitter is used to omit a field based on struct tags. The function can use any logic to parse the

--- a/structs.go
+++ b/structs.go
@@ -20,11 +20,13 @@ type Struct struct {
 	raw     interface{}
 	value   reflect.Value
 	TagName string
-	TagOptsFieldOmitter tagOptsFieldOmitter
+	TagOptsFieldOmitter TagOptsFieldOmitter
 	IncludeEmptyConversions bool
 }
 
-type tagOptsFieldOmitter func(tags []string) bool
+// TagOptsFieldOmitter is used to omit a field based on struct tags. The function can use any logic to parse the
+// tagOptions and return true if the field should be omitted.
+type TagOptsFieldOmitter func(tags []string) bool
 
 // New returns a new *Struct with the struct s. It panics if the s's kind is
 // not struct.
@@ -527,6 +529,7 @@ func (s *Struct) nested(val reflect.Value) interface{} {
 		n := New(val.Interface())
 		n.TagName = s.TagName
 		n.TagOptsFieldOmitter = s.TagOptsFieldOmitter
+		n.IncludeEmptyConversions = s.IncludeEmptyConversions
 		m := n.Map()
 
 		// do not add the converted value if there are no exported fields, ie:

--- a/structs_example_test.go
+++ b/structs_example_test.go
@@ -134,13 +134,13 @@ func ExampleMap_omitEmpty() {
 }
 
 func ExampleMap_TagOptsFieldOmitter() {
+	// Only convert the fields with the whitelist struct tag
 	type Server struct {
 		Name     string `structs:",whitelist"`
 		ID       int32  `structs:",whitelist"`
 		Location string
 	}
 
-	// Only add location
 	server := &Server{
 		Name: "First Last",
 		ID: 1,

--- a/structs_example_test.go
+++ b/structs_example_test.go
@@ -133,6 +133,37 @@ func ExampleMap_omitEmpty() {
 	// map[Location:Tokyo]
 }
 
+func ExampleMap_TagOptsFieldOmitter() {
+	// By default field with struct types of zero values are processed too. We
+	// can stop processing them via "omitempty" tag option.
+	type Server struct {
+		Name     string `structs:",whitelist"`
+		ID       int32  `structs:",whitelist"`
+		Location string
+	}
+
+	// Only add location
+	server := &Server{
+		Name: "First Last",
+		ID: 1,
+		Location: "Tokyo",
+	}
+
+	s := New(server)
+	s.TagOptsFieldOmitter = func(tags []string) bool {
+		if len(tags) > 0 && tags[0] == "whitelist" {
+			return false
+		}
+		return true
+	}
+	m := s.Map()
+
+	// map contains only the Location field
+	fmt.Printf("%v\n", m)
+	// Output:
+	// map[Name:First Last ID:1]
+}
+
 func ExampleValues() {
 	type Server struct {
 		Name    string

--- a/structs_example_test.go
+++ b/structs_example_test.go
@@ -134,8 +134,6 @@ func ExampleMap_omitEmpty() {
 }
 
 func ExampleMap_TagOptsFieldOmitter() {
-	// By default field with struct types of zero values are processed too. We
-	// can stop processing them via "omitempty" tag option.
 	type Server struct {
 		Name     string `structs:",whitelist"`
 		ID       int32  `structs:",whitelist"`
@@ -158,7 +156,6 @@ func ExampleMap_TagOptsFieldOmitter() {
 	}
 	m := s.Map()
 
-	// map contains only the Location field
 	fmt.Printf("%v\n", m)
 	// Output:
 	// map[Name:First Last ID:1]

--- a/structs_example_test.go
+++ b/structs_example_test.go
@@ -136,8 +136,8 @@ func ExampleMap_omitEmpty() {
 func ExampleMap_TagOptsFieldOmitter() {
 	// Only convert the fields with the whitelist struct tag
 	type Server struct {
-		Name     string `structs:",whitelist"`
-		ID       int32  `structs:",whitelist"`
+		Name     string
+		ID       int32 `structs:",whitelist"`
 		Location string
 	}
 
@@ -158,7 +158,7 @@ func ExampleMap_TagOptsFieldOmitter() {
 
 	fmt.Printf("%v\n", m)
 	// Output:
-	// map[Name:First Last ID:1]
+	// map[ID:1]
 }
 
 func ExampleValues() {

--- a/structs_test.go
+++ b/structs_test.go
@@ -210,63 +210,33 @@ func TestMap_OmitEmpty(t *testing.T) {
 	}
 }
 
-func TestMap_TagOptsFieldOmitterFalse(t *testing.T) {
+func TestMap_TagOptsFieldOmitter(t *testing.T) {
 	type A struct {
 		Name  string
-		Value string
+		Value string `structs:",excludeme"`
 		Time  time.Time
 	}
 
 	a := A{}
 	s := New(a)
-	s.TagOptsFieldOmitter = func([]string) bool {return false}
+	s.TagOptsFieldOmitter = func(tags []string) bool {
+		return len(tags) > 0 && tags[0] == "excludeme"
+		}
 	m := s.Map()
-
-	fmt.Println(m)
 
 	_, ok := m["Name"]
 	if !ok {
-		t.Error("Map should contain the Name field because the omitter always returns false")
-	}
-
-	_, ok = m["Value"]
-	if !ok {
-		t.Error("Map should contain the Value field because the omitter always returns false")
-	}
-
-	_, ok = m["Time"].(time.Time)
-	if !ok {
-		t.Error("Map should contain the Time field because the omitter always returns false")
-	}
-}
-
-func TestMap_TagOptsFieldOmitterTrue(t *testing.T) {
-	type A struct {
-		Name  string
-		Value string
-		Time  time.Time
-	}
-
-	a := A{}
-	s := New(a)
-	s.TagOptsFieldOmitter = func([]string) bool {return true}
-	m := s.Map()
-
-	fmt.Println(m)
-
-	_, ok := m["Name"]
-	if ok {
-		t.Error("Map should contain the Name field because the omitter always returns true")
+		t.Error("Map should contain the Name field because it has no tag")
 	}
 
 	_, ok = m["Value"]
 	if ok {
-		t.Error("Map should contain the Value field because the omitter always returns true")
+		t.Error("Map should contain the Value field because its tag is excludeme")
 	}
 
 	_, ok = m["Time"]
-	if ok {
-		t.Error("Map should contain the Time field because the omitter always returns true")
+	if !ok {
+		t.Error("Map should contain the Time field because it has no tag")
 	}
 }
 

--- a/structs_test.go
+++ b/structs_test.go
@@ -210,6 +210,66 @@ func TestMap_OmitEmpty(t *testing.T) {
 	}
 }
 
+func TestMap_TagOptsFieldOmitterFalse(t *testing.T) {
+	type A struct {
+		Name  string
+		Value string
+		Time  time.Time
+	}
+
+	a := A{}
+	s := New(a)
+	s.TagOptsFieldOmitter = func([]string) bool {return false}
+	m := s.Map()
+
+	fmt.Println(m)
+
+	_, ok := m["Name"]
+	if !ok {
+		t.Error("Map should contain the Name field because the omitter always returns false")
+	}
+
+	_, ok = m["Value"]
+	if !ok {
+		t.Error("Map should contain the Value field because the omitter always returns false")
+	}
+
+	_, ok = m["Time"].(time.Time)
+	if !ok {
+		t.Error("Map should contain the Time field because the omitter always returns false")
+	}
+}
+
+func TestMap_TagOptsFieldOmitterTrue(t *testing.T) {
+	type A struct {
+		Name  string
+		Value string
+		Time  time.Time
+	}
+
+	a := A{}
+	s := New(a)
+	s.TagOptsFieldOmitter = func([]string) bool {return true}
+	m := s.Map()
+
+	fmt.Println(m)
+
+	_, ok := m["Name"]
+	if ok {
+		t.Error("Map should contain the Name field because the omitter always returns true")
+	}
+
+	_, ok = m["Value"]
+	if ok {
+		t.Error("Map should contain the Value field because the omitter always returns true")
+	}
+
+	_, ok = m["Time"]
+	if ok {
+		t.Error("Map should contain the Time field because the omitter always returns true")
+	}
+}
+
 func TestMap_OmitNested(t *testing.T) {
 	type A struct {
 		Name  string
@@ -623,6 +683,25 @@ func TestMap_TimeField(t *testing.T) {
 	_, ok := m["CreatedAt"].(time.Time)
 	if !ok {
 		t.Error("Time field must be final")
+	}
+}
+
+func TestMap_TimeFieldIncludeEmptyConversions(t *testing.T) {
+	type A struct {
+		CreatedAt time.Time
+	}
+
+	a := &A{CreatedAt: time.Now().UTC()}
+	s := New(a)
+	s.IncludeEmptyConversions = true
+	m := s.Map()
+
+	ca, ok := m["CreatedAt"].(map[string]interface{})
+	if !ok {
+		t.Error("CreatedAt was not included")
+	}
+	if len(ca) != 0 {
+		t.Error("Conversion was not empty")
 	}
 }
 


### PR DESCRIPTION
Add a `TagOptsFieldOmitter` function to `Struct` that is used to filter fields based on struct tags. 

An example use case is in the `ExampleMap_TagOptsFieldOmitter` test